### PR TITLE
Disable mtest file generation to make generic MFront behaviours compile

### DIFF
--- a/cmake/modules/behaviours.cmake
+++ b/cmake/modules/behaviours.cmake
@@ -39,7 +39,7 @@ function(add_mfront_behaviour_sources lib  file)
     OUTPUT  "${mfront_output2}"
     COMMAND ${CONAN_ENV_CMD} "${MFRONT}"
     ARGS    "--interface=generic"
-    ARGS    "--@GenericInterfaceGenerateMTestFileOnFailure=true"
+    ARGS    "--@GenericInterfaceGenerateMTestFileOnFailure=false"
     ARGS     "${mfront_file}"
     DEPENDS "${mfront_file}"
     COMMENT "mfront source ${mfront_file}")


### PR DESCRIPTION
This change is necessary to make generic MFront behaviours compile.

It's already fixed in the MGIS master, but OGS still uses an old version of MGIS/MFront.